### PR TITLE
fix: handle HTTP error in find_chapter_pages that would cause a crash

### DIFF
--- a/mangaxyz.py
+++ b/mangaxyz.py
@@ -139,7 +139,11 @@ class Provider:
 
     async def find_chapter_pages(self, chapter_id: str):
         async with httpx.AsyncClient(timeout=TIMEOUT) as client:
-            html_page = await self.fetch(client, f"{self.api}/{chapter_id}")
+            try:
+                html_page = await self.fetch(client, f"{self.api}/{chapter_id}")
+            except Exception as e:
+                console.print(f"[red]findChapterPages error:[/red] {e}")
+                return []
         img_var = re.search(r"var\s+chapImages\s*=\s*'([^']+)'", html_page)
         if not img_var:
             debug(f"No chapImages found for {chapter_id}")


### PR DESCRIPTION
The call to fetch at line 142 isn't in a try block, unlike elsewhere in the script. So, the whole thing crashes if the server returns a 5XX error (which just happened to me).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for content fetching operations. The application now gracefully manages fetch failures by logging errors and continuing without interruption, preventing crashes and enhancing overall stability when encountering data retrieval issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->